### PR TITLE
Update workshops.de links with utm parameters

### DIFF
--- a/src/pages/blog/2024-12-20-mistral-free-features-revolution/index.md
+++ b/src/pages/blog/2024-12-20-mistral-free-features-revolution/index.md
@@ -237,4 +237,4 @@ Die Zukunft der AI ist nicht mehr hinter Paywalls versteckt. Mistral hat die Tü
 
 ---
 
-*Übrigens: Wenn du tiefer in die Materie einsteigen willst, check unsere [AI Automation Workshops](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=mistral-free-features-revolution) – dort zeigen wir dir, wie du diese kostenlosen Tools in echte Business-Value verwandelst.*
+*Übrigens: Wenn du tiefer in die Materie einsteigen willst, check unsere [AI Automation Workshops](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=mistral-free-features-revolution) – dort zeigen wir dir, wie du diese kostenlosen Tools in echte Business-Value verwandelst.*

--- a/src/pages/blog/2025-01-14-chatgpt-branching-feature-parallele-konversationen/index.md
+++ b/src/pages/blog/2025-01-14-chatgpt-branching-feature-parallele-konversationen/index.md
@@ -268,4 +268,4 @@ Die Ära der linearen AI-Konversationen ist vorbei. Welcome to the Branching Rev
 
 **Pro-Tipp**: Nutze Branches auch für "Checkpoint-Saves" - erstelle einen Branch bevor du etwas Experimentelles versuchst, so hast du immer einen sauberen Restore-Point.
 
-*Hast du schon coole Use Cases für Branching gefunden? Ich bin gespannt auf deine Erfahrungen! Mehr zu AI Automation und praktischen Workshops findest du auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=chatgpt-branching-feature-parallele-konversationen)*
+*Hast du schon coole Use Cases für Branching gefunden? Ich bin gespannt auf deine Erfahrungen! Mehr zu AI Automation und praktischen Workshops findest du auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=chatgpt-branching-feature-parallele-konversationen)*

--- a/src/pages/blog/2025-01-14-chatgpt-model-context-protocol-integration/index.md
+++ b/src/pages/blog/2025-01-14-chatgpt-model-context-protocol-integration/index.md
@@ -296,4 +296,4 @@ Die Zukunft der AI-Integration ist offen, standardisiert und verdammt aufregend.
 
 ---
 
-*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere MCP-Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=chatgpt-model-context-protocol-integration). Wir bauen gemeinsam produktionsreife MCP-Server und integrieren sie in echte Business-Workflows. Trust me, es wird episch!*
+*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere MCP-Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=chatgpt-model-context-protocol-integration). Wir bauen gemeinsam produktionsreife MCP-Server und integrieren sie in echte Business-Workflows. Trust me, es wird episch!*

--- a/src/pages/blog/2025-01-14-claude-file-editing-revolutioniert-dokumentenarbeit/index.md
+++ b/src/pages/blog/2025-01-14-claude-file-editing-revolutioniert-dokumentenarbeit/index.md
@@ -215,4 +215,4 @@ Die Zukunft der Büroarbeit ist hier – und sie sieht verdammt effizient aus. Z
 
 ---
 
-*Hast du schon Erfahrungen mit Claudes neuen File-Features gemacht? Oder bist du noch skeptisch? Lass es uns wissen und entdecke mehr Möglichkeiten der AI-Automatisierung in unseren Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-file-editing-revolutioniert-dokumentenarbeit)!*
+*Hast du schon Erfahrungen mit Claudes neuen File-Features gemacht? Oder bist du noch skeptisch? Lass es uns wissen und entdecke mehr Möglichkeiten der AI-Automatisierung in unseren Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-file-editing-revolutioniert-dokumentenarbeit)!*

--- a/src/pages/blog/2025-01-14-google-notebooklm-ki-forschungsassistent-revolutioniert-wissensarbeit/index.md
+++ b/src/pages/blog/2025-01-14-google-notebooklm-ki-forschungsassistent-revolutioniert-wissensarbeit/index.md
@@ -250,4 +250,4 @@ Die Art, wie wir forschen, lernen und Wissen verarbeiten, hat sich gerade fundam
 
 ---
 
-**P.S.:** Wenn du tiefer in die Welt der AI-Tools eintauchen willst, check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=google-notebooklm-ki-forschungsassistent-revolutioniert-wissensarbeit). Wir zeigen dir, wie du NotebookLM und andere KI-Werkzeuge in deinen Workflow integrierst - hands-on und praxisnah!
+**P.S.:** Wenn du tiefer in die Welt der AI-Tools eintauchen willst, check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=google-notebooklm-ki-forschungsassistent-revolutioniert-wissensarbeit). Wir zeigen dir, wie du NotebookLM und andere KI-Werkzeuge in deinen Workflow integrierst - hands-on und praxisnah!

--- a/src/pages/blog/2025-01-14-langflow-visueller-ki-workflow-builder/index.md
+++ b/src/pages/blog/2025-01-14-langflow-visueller-ki-workflow-builder/index.md
@@ -196,7 +196,7 @@ Für 80% der Use-Cases ist es der schnellste Weg von Idee zu funktionierender KI
 2. **Baue deinen ersten Flow** (starte mit einer Template)
 3. **Teile deine Kreation** (die Community liebt neue Flows)
 
-Und wenn du richtig durchstarten willst: Die **[AI Automation Engineers Workshops](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=langflow-visueller-ki-workflow-builder)** zeigen dir, wie du Langflow in Production-Ready-Systeme integrierst.
+Und wenn du richtig durchstarten willst: Die **[AI Automation Engineers Workshops](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=langflow-visueller-ki-workflow-builder)** zeigen dir, wie du Langflow in Production-Ready-Systeme integrierst.
 
 **Remember:** In einer Welt, wo jeder KI-Apps bauen kann, sind die Kreativen die neuen Könige. Langflow gibt dir das Zepter – was du damit machst, liegt bei dir.
 

--- a/src/pages/blog/2025-01-18-wie-menschen-chatgpt-wirklich-nutzen/index.md
+++ b/src/pages/blog/2025-01-18-wie-menschen-chatgpt-wirklich-nutzen/index.md
@@ -183,6 +183,6 @@ Du willst lernen, wie du ChatGPT und andere KI-Tools optimal in deine Workflows 
 
 Schau dir unsere AI-Automation Workshops an: Von ChatGPT-Integration über Custom GPTs bis zu vollständigen Automatisierungs-Pipelines.
 
-[Jetzt Workshop-Platz sichern auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=wie-menschen-chatgpt-wirklich-nutzen)
+[Jetzt Workshop-Platz sichern auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=wie-menschen-chatgpt-wirklich-nutzen)
 
 Die Zukunft wartet nicht - sei dabei, wenn wir sie gestalten! 🎯

--- a/src/pages/blog/2025-01-20-google-sheets-ai-revolution-smart-fill-cleanup-gemini/index.md
+++ b/src/pages/blog/2025-01-20-google-sheets-ai-revolution-smart-fill-cleanup-gemini/index.md
@@ -269,4 +269,4 @@ Die Zukunft der Datenverarbeitung ist nicht kompliziert – sie ist smart, intui
 
 ---
 
-*PS: Für alle, die noch tiefer in die Materie einsteigen wollen: Schaut euch unsere [AI-Automation Workshops](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=google-sheets-ai-revolution-smart-fill-cleanup-gemini) an, wo wir hands-on zeigen, wie ihr Google Sheets AI mit anderen Tools wie n8n und Make zu einem vollautomatischen Daten-Powerhouse kombiniert.*
+*PS: Für alle, die noch tiefer in die Materie einsteigen wollen: Schaut euch unsere [AI-Automation Workshops](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=google-sheets-ai-revolution-smart-fill-cleanup-gemini) an, wo wir hands-on zeigen, wie ihr Google Sheets AI mit anderen Tools wie n8n und Make zu einem vollautomatischen Daten-Powerhouse kombiniert.*

--- a/src/pages/blog/2025-01-23-hubspot-loop-marketing-framework-ai-automation-revolution/index.md
+++ b/src/pages/blog/2025-01-23-hubspot-loop-marketing-framework-ai-automation-revolution/index.md
@@ -183,4 +183,4 @@ Und denk dran: In der Loop gibt es kein Scheitern, nur Datenpunkte für die näc
 
 ---
 
-*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere [AI Marketing Automation Workshops](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=hubspot-loop-marketing-framework-ai-automation-revolution) - dort zeigen wir dir hands-on, wie du dein eigenes Loop-System aufbaust. Keine Buzzwords, nur echte Implementierung.*
+*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere [AI Marketing Automation Workshops](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=hubspot-loop-marketing-framework-ai-automation-revolution) - dort zeigen wir dir hands-on, wie du dein eigenes Loop-System aufbaust. Keine Buzzwords, nur echte Implementierung.*

--- a/src/pages/blog/2025-01-23-hubspot-loop-marketing-framework-ai-automation/index.md
+++ b/src/pages/blog/2025-01-23-hubspot-loop-marketing-framework-ai-automation/index.md
@@ -300,6 +300,6 @@ Das Schöne am Loop Marketing? Es ist wie ein guter Wein - es wird mit der Zeit 
 
 **Lust auf mehr?** In unserem Workshop "AI-Driven Marketing Automation" zeigen wir dir hands-on, wie du Loop Marketing mit n8n, Python und den neuesten AI-Tools implementierst. Von der ersten Automation bis zum selbstoptimierenden Marketing-System.
 
-[Jetzt Workshop buchen](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=hubspot-loop-marketing-framework-ai-automation)
+[Jetzt Workshop buchen](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=hubspot-loop-marketing-framework-ai-automation)
 
 Die Zukunft des Marketings ist zirkulär, intelligent und verdammt effizient. Bist du ready für den Loop? 🔄✨

--- a/src/pages/blog/2025-01-29-openai-knackt-mathe-olympiade-goldmedaille/index.md
+++ b/src/pages/blog/2025-01-29-openai-knackt-mathe-olympiade-goldmedaille/index.md
@@ -164,7 +164,7 @@ Du willst tiefer in die Welt der KI-Reasoning eintauchen? Hier sind deine nächs
 
 Die Zukunft der Mathematik - und damit der Wissenschaft - wird gerade neu geschrieben. Und du kannst Teil davon sein.
 
-**[Entdecke unsere KI-Workshops](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-knackt-mathe-olympiade-goldmedaille)** und lerne, wie du die Power von Reasoning-Modellen für deine Projekte nutzen kannst.
+**[Entdecke unsere KI-Workshops](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-knackt-mathe-olympiade-goldmedaille)** und lerne, wie du die Power von Reasoning-Modellen für deine Projekte nutzen kannst.
 
 Die Mathematik-Olympiade war erst der Anfang. Die echte Goldmedaille? Die holen wir uns gemeinsam in der Zukunft. 🏆
 

--- a/src/pages/blog/2025-08-13-langflow-low-code-ai-revolution/index.md
+++ b/src/pages/blog/2025-08-13-langflow-low-code-ai-revolution/index.md
@@ -235,7 +235,7 @@ Die AI-Revolution braucht nicht nur bessere Modelle. Sie braucht bessere Tools, 
 
 Und wenn du richtig durchstarten willst? Wir haben einen Workshop "**From Zero to AI Hero mit Langflow**" - dort bauen wir gemeinsam Production-Ready AI Agents. In 4 Stunden vom Langflow-Newbie zum Flow-Architekt.
 
-**[Jetzt Workshop buchen](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=langflow-low-code-ai-revolution)**
+**[Jetzt Workshop buchen](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=langflow-low-code-ai-revolution)**
 
 Happy Flowing! Und remember: Die besten AI-Lösungen entstehen nicht aus perfektem Code, sondern aus schnellen Iterationen. Langflow macht genau das möglich. 🚀
 

--- a/src/pages/blog/2025-08-13-ollama-lokale-ki-revolution-chatgpt-alternative/index.md
+++ b/src/pages/blog/2025-08-13-ollama-lokale-ki-revolution-chatgpt-alternative/index.md
@@ -237,6 +237,6 @@ Die neue Desktop-App macht den Einstieg so einfach wie nie. Du hast keine Ausred
 
 ---
 
-*P.S.: Wenn du tiefer in die Materie einsteigen willst, check unseren Workshop "Local AI Mastery" aus. Wir bauen gemeinsam einen kompletten KI-Stack auf deinem Rechner auf – von Ollama bis zu eigenen Agents. [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=ollama-lokale-ki-revolution-chatgpt-alternative)*
+*P.S.: Wenn du tiefer in die Materie einsteigen willst, check unseren Workshop "Local AI Mastery" aus. Wir bauen gemeinsam einen kompletten KI-Stack auf deinem Rechner auf – von Ollama bis zu eigenen Agents. [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=ollama-lokale-ki-revolution-chatgpt-alternative)*
 
 Die Zukunft der KI ist lokal, privat und unter deiner Kontrolle. Bist du dabei? 🚀

--- a/src/pages/blog/2025-08-21-claude-code-revolution-entwickler-workflows/index.md
+++ b/src/pages/blog/2025-08-21-claude-code-revolution-entwickler-workflows/index.md
@@ -341,4 +341,4 @@ Die Zukunft der Entwicklung ist nicht "AI ersetzt Entwickler", sondern "Entwickl
 
 **Interessiert an einem Deep-Dive Workshop?** Wir zeigen dir, wie du Claude Code optimal für deine spezifischen Use Cases einsetzt. Von der Installation bis zu fortgeschrittenen Workflows – alles hands-on!
 
-[🎯 Claude Code Mastery Workshop buchen](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-code-revolution-entwickler-workflows)
+[🎯 Claude Code Mastery Workshop buchen](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-code-revolution-entwickler-workflows)

--- a/src/pages/blog/2025-09-12-ki-produkthaftung-justizministerium-gesetzentwurf/index.md
+++ b/src/pages/blog/2025-09-12-ki-produkthaftung-justizministerium-gesetzentwurf/index.md
@@ -156,7 +156,7 @@ Die Tech-Branche reagiert gemischt. Während große Unternehmen die Rechtssicher
 - 🇪🇺 [EU-Produkthaftungsrichtlinie 2024/2853](https://eur-lex.europa.eu)
 - 📖 [AI Act Compliance Guide](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai)
 - 💼 [Bitkom-Stellungnahme](https://www.bitkom.org)
-- 🎓 [Schulungsangebote zur KI-Haftung](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=ki-produkthaftung-justizministerium-gesetzentwurf)
+- 🎓 [Schulungsangebote zur KI-Haftung](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=ki-produkthaftung-justizministerium-gesetzentwurf)
 
 ## Fazit
 

--- a/src/pages/blog/2025-09-12-mcp-protokoll-macht-agentische-ki-zum-standard/index.md
+++ b/src/pages/blog/2025-09-12-mcp-protokoll-macht-agentische-ki-zum-standard/index.md
@@ -306,7 +306,7 @@ MCP ist mehr als nur ein weiteres Protokoll. Es ist der Missing Link, der aus is
 Wenn ihr tiefer einsteigen wollt, hier eure Next Steps:
 
 - 🔧 **Technische Docs**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
-- 🎓 **MCP Workshop**: Hands-on Training für Teams (coming soon auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=mcp-protokoll-macht-agentische-ki-zum-standard))
+- 🎓 **MCP Workshop**: Hands-on Training für Teams (coming soon auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=mcp-protokoll-macht-agentische-ki-zum-standard))
 - 💬 **Community**: MCP Developer Discord (5000+ Mitglieder)
 - 📚 **GitHub**: Beispiel-Implementierungen und Best Practices
 

--- a/src/pages/blog/2025-09-13-cursor-cli-ai-coding-direkt-im-terminal/index.md
+++ b/src/pages/blog/2025-09-13-cursor-cli-ai-coding-direkt-im-terminal/index.md
@@ -225,4 +225,4 @@ Die Terminal-Revolution hat begonnen. Die Frage ist nicht ob, sondern wie schnel
 
 ---
 
-*PS: Für alle die tiefer einsteigen wollen – wir planen einen Workshop zu "Advanced Cursor CLI & MCP Integration". Stay tuned auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=cursor-cli-ai-coding-direkt-im-terminal)!*
+*PS: Für alle die tiefer einsteigen wollen – wir planen einen Workshop zu "Advanced Cursor CLI & MCP Integration". Stay tuned auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=cursor-cli-ai-coding-direkt-im-terminal)!*

--- a/src/pages/blog/2025-09-14-claude-teams-memory-geteiltes-wissen-neue-aera/index.md
+++ b/src/pages/blog/2025-09-14-claude-teams-memory-geteiltes-wissen-neue-aera/index.md
@@ -216,6 +216,6 @@ Die Zeiten, in denen KI-Assistenten bei jedem Chat bei Null anfangen, sind vorbe
 
 ---
 
-*Willst du mehr über AI-gestützte Team-Kollaboration lernen? Check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-teams-memory-geteiltes-wissen-neue-aera) - dort zeigen wir dir hands-on, wie du Claude Teams Memory optimal für dein Team einsetzt.*
+*Willst du mehr über AI-gestützte Team-Kollaboration lernen? Check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-teams-memory-geteiltes-wissen-neue-aera) - dort zeigen wir dir hands-on, wie du Claude Teams Memory optimal für dein Team einsetzt.*
 
 Die Zukunft der Team-Zusammenarbeit ist nicht nur intelligent - sie hat jetzt auch ein Gedächtnis. Und trust me, das ändert alles. 🧠✨

--- a/src/pages/blog/2025-09-14-openai-whisper-spracherkennung-revolution/index.md
+++ b/src/pages/blog/2025-09-14-openai-whisper-spracherkennung-revolution/index.md
@@ -435,4 +435,4 @@ Die Zukunft der Spracherkennung ist hier – und sie spricht deine Sprache! 🎙
 
 *Hast du schon Erfahrungen mit Whisper gemacht? Welche Use Cases siehst du für deine Projekte? Lass es uns in den Kommentaren wissen!*
 
-**Workshop-Tipp:** Du willst Whisper professionell in deine Workflows integrieren? Check unsere Hands-On Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-whisper-spracherkennung-revolution) – von Zero to Production in einem Tag! 🚀
+**Workshop-Tipp:** Du willst Whisper professionell in deine Workflows integrieren? Check unsere Hands-On Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-whisper-spracherkennung-revolution) – von Zero to Production in einem Tag! 🚀

--- a/src/pages/blog/2025-09-24-reinforcement-learning-environments-milliarden-dollar-markt/index.md
+++ b/src/pages/blog/2025-09-24-reinforcement-learning-environments-milliarden-dollar-markt/index.md
@@ -192,4 +192,4 @@ Die wahre Revolution liegt nicht darin, Menschen zu ersetzen, sondern darin, sie
 
 ---
 
-*Willst du tiefer in die Welt der KI-Automation eintauchen? Check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=reinforcement-learning-environments-milliarden-dollar-markt), wo wir dir zeigen, wie du realistische KI-Lösungen baust – ohne Milliarden-Budget und mit deutlich weniger Reward Hacking.* 🚀
+*Willst du tiefer in die Welt der KI-Automation eintauchen? Check unsere Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=reinforcement-learning-environments-milliarden-dollar-markt), wo wir dir zeigen, wie du realistische KI-Lösungen baust – ohne Milliarden-Budget und mit deutlich weniger Reward Hacking.* 🚀

--- a/src/pages/blog/2025-09-25-opusclip-game-changer-video-automation/index.md
+++ b/src/pages/blog/2025-09-25-opusclip-game-changer-video-automation/index.md
@@ -313,4 +313,4 @@ Trust me, dein zukünftiges Ich wird dir danken. Welcome to the Video Automation
 
 ---
 
-*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere AI-Automation Workshops auf [workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=opusclip-game-changer-video-automation) - dort zeigen wir dir live, wie du solche Systeme aufbaust.*
+*PS: Wenn du tiefer in die Materie einsteigen willst, check unsere AI-Automation Workshops auf [workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=opusclip-game-changer-video-automation) - dort zeigen wir dir live, wie du solche Systeme aufbaust.*

--- a/src/pages/blog/2025-10-07-sora-2-openai-video-ki-revolution/index.md
+++ b/src/pages/blog/2025-10-07-sora-2-openai-video-ki-revolution/index.md
@@ -226,7 +226,7 @@ Du willst hands-on mit Video-KI arbeiten und eigene Automatisierungen bauen? In 
 - Automatisierungs-Workflows mit n8n
 - Real-World Projekte mit Sora & Co.
 
-[Jetzt Workshop-Platz sichern](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=sora-2-openai-video-ki-revolution)
+[Jetzt Workshop-Platz sichern](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=sora-2-openai-video-ki-revolution)
 
 ---
 

--- a/src/pages/blog/2025-10-09-openai-dev-day-2025-chatgpt-apps-agentkit-revolution/index.md
+++ b/src/pages/blog/2025-10-09-openai-dev-day-2025-chatgpt-apps-agentkit-revolution/index.md
@@ -206,7 +206,7 @@ Die AI-Automation Engineers bieten einen **Deep-Dive Workshop** zu den neuen Ope
 - Cost-Optimization Strategien
 - Security & Compliance Guidelines
 
-[Jetzt Workshop buchen](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-dev-day-2025-chatgpt-apps-agentkit-revolution)
+[Jetzt Workshop buchen](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-dev-day-2025-chatgpt-apps-agentkit-revolution)
 
 ## Fazit
 

--- a/src/pages/blog/2025-10-10-github-spec-kit-revolution-ai-coding/index.md
+++ b/src/pages/blog/2025-10-10-github-spec-kit-revolution-ai-coding/index.md
@@ -243,6 +243,6 @@ GitHub Spec Kit ist nicht perfekt, aber es löst ein echtes Problem: Das Chaos i
 
 *Du willst mehr über strukturiertes AI-Coding lernen? In unseren Hands-on Workshops zeigen wir dir, wie du Spec Kit und andere AI-Tools produktiv einsetzt. Von der Spec bis zur Production-Ready App - alles praktisch, alles hands-on.*
 
-**[🎯 Jetzt Workshop-Platz sichern auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spec-kit-revolution-ai-coding)**
+**[🎯 Jetzt Workshop-Platz sichern auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spec-kit-revolution-ai-coding)**
 
 Die Revolution des AI-Codings hat begonnen. Spec-driven Development ist nicht nur ein Buzzword - es ist der Weg aus dem Vibe-Coding-Chaos. Zeit, dass du dabei bist! 🚀

--- a/src/pages/blog/2025-10-10-tesla-bottle-rocket-ki-datensicherheit-unternehmen/index.md
+++ b/src/pages/blog/2025-10-10-tesla-bottle-rocket-ki-datensicherheit-unternehmen/index.md
@@ -254,7 +254,7 @@ Wir bei AI Automation Engineers haben bereits dutzende Unternehmen bei der Imple
 - Individuelle Strategie-Entwicklung
 - Best Practices aus 50+ Projekten
 
-[Jetzt Workshop buchen](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=tesla-bottle-rocket-ki-datensicherheit-unternehmen)
+[Jetzt Workshop buchen](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=tesla-bottle-rocket-ki-datensicherheit-unternehmen)
 
 Die Zukunft der Unternehmens-KI ist privat, sicher und selbstbestimmt. Tesla hat's vorgemacht – jetzt bist du dran! 🚀
 

--- a/src/pages/blog/2025-11-13-26-filmische-begriffe-die-deine-ai-videos-revolutionieren/index.md
+++ b/src/pages/blog/2025-11-13-26-filmische-begriffe-die-deine-ai-videos-revolutionieren/index.md
@@ -204,7 +204,7 @@ Dieser Workflow läuft vollautomatisch und produziert hochwertige Visuals im Sch
 
 - 📚 [Runway Gen-3 Prompting Guide](https://runwayml.com/research/gen-3)
 
-- 🎓 [AI-Video Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=26-filmische-begriffe-die-deine-ai-videos-revolutionieren)
+- 🎓 [AI-Video Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=26-filmische-begriffe-die-deine-ai-videos-revolutionieren)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 06.11.2025*

--- a/src/pages/blog/2025-11-13-ai-automation-engineers-microsoft-autonomous-ai-agents-revolution/index.md
+++ b/src/pages/blog/2025-11-13-ai-automation-engineers-microsoft-autonomous-ai-agents-revolution/index.md
@@ -270,7 +270,7 @@ Die neuen Microsoft Autonomous Agents sind keine Evolution, sondern eine **Revol
 
 - 🛠️ [Azure AI Agent Service](https://azure.microsoft.com/services/ai-agent-service)
 
-- 🎓 [Workshop: "AI Agents in der Praxis" auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=ai-automation-engineers-microsoft-autonomous-ai-agents-revolution)
+- 🎓 [Workshop: "AI Agents in der Praxis" auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=ai-automation-engineers-microsoft-autonomous-ai-agents-revolution)
 
 - 💬 [Microsoft AI Agents Community Hub](https://adoption.microsoft.com/ai-agents)
 

--- a/src/pages/blog/2025-11-13-amazon-vs-perplexity-wenn-ki-agenten-zu-autonom-werden/index.md
+++ b/src/pages/blog/2025-11-13-amazon-vs-perplexity-wenn-ki-agenten-zu-autonom-werden/index.md
@@ -177,7 +177,7 @@ Der Rechtsstreit zwischen Amazon und Perplexity ist mehr als nur ein Einzelfall.
 
 - 📊 [Meedia - Browser-Agent Details](https://meedia.de/news/beitrag/20510-amazon-verklagt-perplexity-wegen-ai-browser-comet.html)
 
-- 🎓 [Workshop: Ethische KI-Automatisierung auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=amazon-vs-perplexity-wenn-ki-agenten-zu-autonom-werden)
+- 🎓 [Workshop: Ethische KI-Automatisierung auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=amazon-vs-perplexity-wenn-ki-agenten-zu-autonom-werden)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 09.11.2025*

--- a/src/pages/blog/2025-11-13-frugal-ai-wie-unternehmen-mit-weniger-daten-mehr-erreichen-und-das-klima-schuetzen/index.md
+++ b/src/pages/blog/2025-11-13-frugal-ai-wie-unternehmen-mit-weniger-daten-mehr-erreichen-und-das-klima-schuetzen/index.md
@@ -114,7 +114,7 @@ Frugal AI ist mehr als ein Trend – es ist eine notwendige Evolution in der KI-
 
 - 📚 [NetApp Solutions für energieeffiziente Storage-Systeme](https://www.netapp.com)
 
-- 🎓 [Workshops zu Green IT und nachhaltiger KI-Strategie auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=frugal-ai-wie-unternehmen-mit-weniger-daten-mehr-erreichen-und-das-klima-schuetzen)
+- 🎓 [Workshops zu Green IT und nachhaltiger KI-Strategie auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=frugal-ai-wie-unternehmen-mit-weniger-daten-mehr-erreichen-und-das-klima-schuetzen)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 09.11.2025*

--- a/src/pages/blog/2025-11-13-gemini-api-structured-outputs-mit-erweitertem-json-schema-native-pydantic-zod-integration-fuer-ai-agents/index.md
+++ b/src/pages/blog/2025-11-13-gemini-api-structured-outputs-mit-erweitertem-json-schema-native-pydantic-zod-integration-fuer-ai-agents/index.md
@@ -346,7 +346,7 @@ Die erweiterte JSON Schema Unterstützung in der Gemini API ist ein Game-Changer
 
 - 💻 [TypeScript SDK mit Zod Integration](https://github.com/google/generative-ai-js)
 
-- 🎓 [AI Automation Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=gemini-api-structured-outputs-mit-erweitertem-json-schema-native-pydantic-zod-integration-fuer-ai-agents)
+- 🎓 [AI Automation Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=gemini-api-structured-outputs-mit-erweitertem-json-schema-native-pydantic-zod-integration-fuer-ai-agents)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 2025-11-10*

--- a/src/pages/blog/2025-11-13-github-copilot-meisterkurs-so-automatisieren-entwickler-building-testing-und-deployment/index.md
+++ b/src/pages/blog/2025-11-13-github-copilot-meisterkurs-so-automatisieren-entwickler-building-testing-und-deployment/index.md
@@ -257,7 +257,7 @@ Die Investition von $10/Monat amortisiert sich bereits nach 2-3 eingesparten Arb
 
 - 🔧 [n8n GitHub Integration Guide](https://n8n.io/integrations/github/)
 
-- 🎓 [AI-Automation Workshop: KI-gestützte Entwicklung](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-meisterkurs-so-automatisieren-entwickler-building-testing-und-deployment)
+- 🎓 [AI-Automation Workshop: KI-gestützte Entwicklung](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-meisterkurs-so-automatisieren-entwickler-building-testing-und-deployment)
 
 - 💡 [Model Context Protocol Explained](https://xebia.com/blog/ai-agents-with-mcp/)
 

--- a/src/pages/blog/2025-11-13-github-isst-den-eigenen-hundefutter-wie-copilot-die-github-plattform-selbst-baut/index.md
+++ b/src/pages/blog/2025-11-13-github-isst-den-eigenen-hundefutter-wie-copilot-die-github-plattform-selbst-baut/index.md
@@ -276,7 +276,7 @@ Der nächste logische Schritt? Starte ein Pilot-Projekt, messe die Ergebnisse un
 
 - 📚 [GitHub Copilot Dokumentation](https://docs.github.com/en/copilot)
 
-- 🎓 [AI-Automation Workshop: GitHub Copilot im Enterprise-Einsatz](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-isst-den-eigenen-hundefutter-wie-copilot-die-github-plattform-selbst-baut)
+- 🎓 [AI-Automation Workshop: GitHub Copilot im Enterprise-Einsatz](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-isst-den-eigenen-hundefutter-wie-copilot-die-github-plattform-selbst-baut)
 
 - 🔧 [GitHub Universe 2025: AgentHQ Announcement](https://githubuniverse.com)
 

--- a/src/pages/blog/2025-11-13-github-revolutioniert-ki-entwicklung-mit-multi-agent-platform/index.md
+++ b/src/pages/blog/2025-11-13-github-revolutioniert-ki-entwicklung-mit-multi-agent-platform/index.md
@@ -294,7 +294,7 @@ Die Frage ist nicht ob, sondern wann Sie auf Multi-Agent Development umsteigen. 
 
 - 📚 [GitHub Copilot Documentation](https://docs.github.com/en/copilot)
 
-- 🎓 [Workshop: Multi-Agent Systems für Developer](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-revolutioniert-ki-entwicklung-mit-multi-agent-platform)
+- 🎓 [Workshop: Multi-Agent Systems für Developer](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-revolutioniert-ki-entwicklung-mit-multi-agent-platform)
 
 - 🤖 [GitHub Features Übersicht](https://github.com/features) - *Keine dedizierte Agent HQ Waitlist verfügbar*
 

--- a/src/pages/blog/2025-11-13-it-sicherheitsbeauftragte-und-cisos-gefragte-experten-in-zeiten-steigender-cyberbedrohungen/index.md
+++ b/src/pages/blog/2025-11-13-it-sicherheitsbeauftragte-und-cisos-gefragte-experten-in-zeiten-steigender-cyberbedrohungen/index.md
@@ -107,7 +107,7 @@ In der Praxis zeigt sich: Unternehmen mit qualifizierten IT-Sicherheitsbeauftrag
 
 - 📚 [Bitkom Studie Wirtschaftsschutz 2025](https://www.bitkom.org/Bitkom/Publikationen/Studie-Wirtschaftsschutz)
 
-- 🎓 [Weitere IT-Security Workshops auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=it-sicherheitsbeauftragte-und-cisos-gefragte-experten-in-zeiten-steigender-cyberbedrohungen)
+- 🎓 [Weitere IT-Security Workshops auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=it-sicherheitsbeauftragte-und-cisos-gefragte-experten-in-zeiten-steigender-cyberbedrohungen)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 22.10.2025*

--- a/src/pages/blog/2025-11-13-kimi-k2-thinking-open-source-modell-uebertrifft-gpt-und-claude-bei-automatisierung/index.md
+++ b/src/pages/blog/2025-11-13-kimi-k2-thinking-open-source-modell-uebertrifft-gpt-und-claude-bei-automatisierung/index.md
@@ -192,7 +192,7 @@ Kimi K2 Thinking zeigt, wohin die Reise geht: **Von reaktiven Chatbots zu proakt
 
 - 📚 [GitHub Repository](https://github.com/moonshotai/kimi-k2) (wenn verfügbar)
 
-- 🎓 [AI-Automation Workshop: Building Agentic Systems](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=kimi-k2-thinking-open-source-modell-uebertrifft-gpt-und-claude-bei-automatisierung)
+- 🎓 [AI-Automation Workshop: Building Agentic Systems](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=kimi-k2-thinking-open-source-modell-uebertrifft-gpt-und-claude-bei-automatisierung)
 
 - 🔧 [Community Discord für Kimi K2 Entwickler](https://discord.gg/kimi-k2)
 

--- a/src/pages/blog/2025-11-13-microsoft-investiert-10-mrd-dollar-in-europas-groesstes-ki-zentrum-mit-12-600-nvidia-gpus/index.md
+++ b/src/pages/blog/2025-11-13-microsoft-investiert-10-mrd-dollar-in-europas-groesstes-ki-zentrum-mit-12-600-nvidia-gpus/index.md
@@ -172,7 +172,7 @@ Diese Investition wird den europäischen KI-Automatisierungsmarkt fundamental ve
 
 - 🔧 [Nvidia Blackwell Architecture Guide](https://www.nvidia.com/blackwell/)
 
-- 🎓 [AI-Automation Workshop: Enterprise LLM Integration](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-investiert-10-mrd-dollar-in-europas-groesstes-ki-zentrum-mit-12-600-nvidia-gpus)
+- 🎓 [AI-Automation Workshop: Enterprise LLM Integration](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-investiert-10-mrd-dollar-in-europas-groesstes-ki-zentrum-mit-12-600-nvidia-gpus)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 2025-11-12*

--- a/src/pages/blog/2025-11-13-microsoft-researcher-agent-autonome-web-automation-in-copilot/index.md
+++ b/src/pages/blog/2025-11-13-microsoft-researcher-agent-autonome-web-automation-in-copilot/index.md
@@ -214,7 +214,7 @@ Die Zeitersparnis von bis zu 90% bei Research-Tasks ist keine Übertreibung - es
 
 - 📖 [Microsoft 365 Copilot Overview](https://learn.microsoft.com/en-us/copilot/overview)
 
-- 🎓 [AI & Automation Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-researcher-agent-autonome-web-automation-in-copilot)
+- 🎓 [AI & Automation Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-researcher-agent-autonome-web-automation-in-copilot)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 08. November 2025*

--- a/src/pages/blog/2025-11-13-microsoft-startet-revolution-autonome-ki-agents-uebernehmen-ab-november-eigenstaendig-komplette-workflows/index.md
+++ b/src/pages/blog/2025-11-13-microsoft-startet-revolution-autonome-ki-agents-uebernehmen-ab-november-eigenstaendig-komplette-workflows/index.md
@@ -274,7 +274,7 @@ Die neuen Microsoft Autonomous Agents sind keine Evolution, sondern eine **Revol
 
 - 🛠️ [Azure AI Agent Service](https://azure.microsoft.com/services/ai-agent-service)
 
-- 🎓 [Workshop: "AI Agents in der Praxis" auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-startet-revolution-autonome-ki-agents-uebernehmen-ab-november-eigenstaendig-komplette-workflows)
+- 🎓 [Workshop: "AI Agents in der Praxis" auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=microsoft-startet-revolution-autonome-ki-agents-uebernehmen-ab-november-eigenstaendig-komplette-workflows)
 
 - 💬 [Microsoft AI Agents Community Hub](https://adoption.microsoft.com/ai-agents)
 

--- a/src/pages/blog/2025-11-13-nebuis-meta-auftrag-ki-infrastruktur/index.md
+++ b/src/pages/blog/2025-11-13-nebuis-meta-auftrag-ki-infrastruktur/index.md
@@ -188,7 +188,7 @@ Die Integration mit bestehenden Automatisierungs-Tools wie n8n, Make oder Zapier
 
 - 🔗 [Handelsblatt - KI-Cloudfirma Nebius](https://www.handelsblatt.com/technik/ki/kuenstliche-intelligenz-ki-cloudfirma-nebius-erhaelt-milliardenauftrag-von-meta/100173545.html)
 
-- 🎓 [Workshop: Cloud-Native AI Infrastructure](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=nebuis-meta-auftrag-ki-infrastruktur)
+- 🎓 [Workshop: Cloud-Native AI Infrastructure](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=nebuis-meta-auftrag-ki-infrastruktur)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 12.11.2025*

--- a/src/pages/blog/2025-11-13-typescript-wird-zur-wichtigsten-programmiersprache-im-ai-zeitalter/index.md
+++ b/src/pages/blog/2025-11-13-typescript-wird-zur-wichtigsten-programmiersprache-im-ai-zeitalter/index.md
@@ -132,7 +132,7 @@ Die GitHub Octoverse 2025 Daten unterstützen diese Vision: In den Top-10 Open-S
 
 - 📚 [TypeScript 7 Native Preview Ankündigung](https://developer.microsoft.com/blog/typescript-7-native-preview-in-visual-studio-2026)
 
-- 🎓 [TypeScript Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=typescript-wird-zur-wichtigsten-programmiersprache-im-ai-zeitalter)
+- 🎓 [TypeScript Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=typescript-wird-zur-wichtigsten-programmiersprache-im-ai-zeitalter)
 
 ---
 *Recherchiert mit: Perplexity AI | Stand: 07.11.2025*

--- a/src/pages/blog/2025-11-13-urheberpauschale-fuer-ki-training-was-bedeutet-das-fuer-ai-automation-praktiker/index.md
+++ b/src/pages/blog/2025-11-13-urheberpauschale-fuer-ki-training-was-bedeutet-das-fuer-ai-automation-praktiker/index.md
@@ -227,7 +227,7 @@ Die Integration mit Tools wie n8n, Make oder Zapier wird entscheidend sein - hie
 
 - 📚 [EU AI Act Übersicht](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai)
 
-- 🎓 [Workshop: KI-Compliance in der Praxis](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=urheberpauschale-fuer-ki-training-was-bedeutet-das-fuer-ai-automation-praktiker)
+- 🎓 [Workshop: KI-Compliance in der Praxis](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=urheberpauschale-fuer-ki-training-was-bedeutet-das-fuer-ai-automation-praktiker)
 
 - 🔗 [Initiative Urheberrecht](https://urheber.info)
 

--- a/src/pages/blog/2025-11-14-metadata-block/index.md
+++ b/src/pages/blog/2025-11-14-metadata-block/index.md
@@ -99,7 +99,7 @@ Die Zeitersparnis von 70% bei dokumentenlastigen Workflows und die nahtlose Inte
 - 📰 [Google Official Blog: Private AI Compute](https://blog.google/technology/ai/google-private-ai-compute/)
 - 📚 [Google Blog: Private AI Compute Technical Deep Dive](https://blog.google/technology/ai/google-private-ai-compute/)
 - 🔧 [Google Cloud AI Plattform](https://cloud.google.com/ai)
-- 🎓 [Workshop: Enterprise AI Security & Automation](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=metadata-block)
+- 🎓 [Workshop: Enterprise AI Security & Automation](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=metadata-block)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 14.11.2025*
 ---

--- a/src/pages/blog/2025-11-14-sap-joule-ki-agenten-revolutionieren-enterprise-automation-ohne-stellenabbau/index.md
+++ b/src/pages/blog/2025-11-14-sap-joule-ki-agenten-revolutionieren-enterprise-automation-ohne-stellenabbau/index.md
@@ -106,7 +106,7 @@ Für Automatisierungs-Praktiker bedeutet das: Es ist Zeit, SAP-Workflows neu zu 
 - 📰 [Original-Artikel n-tv](https://www.n-tv.de)
 - 📚 [DSAG Positionspapier SAP-KI-Strategie](https://impulsant-dsag.de/wp-content/uploads/2024/10/20241004_Positionspapier_SAP-KI-Strategie.pdf)
 - 🔧 [SAP Signavio November 2024 Release Notes](https://community.sap.com/t5/technology-blog-posts-by-sap/out-now-sap-signavio-november-2024-release/ba-p/13927958)
-- 🎓 [AI & Automation Workshops auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=sap-joule-ki-agenten-revolutionieren-enterprise-automation-ohne-stellenabbau)
+- 🎓 [AI & Automation Workshops auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=sap-joule-ki-agenten-revolutionieren-enterprise-automation-ohne-stellenabbau)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 14.11.2024*
 ---

--- a/src/pages/blog/2025-11-14-typescript-ueberholt-python-der-ai-feedback-loop-revolutioniert-die-entwicklung/index.md
+++ b/src/pages/blog/2025-11-14-typescript-ueberholt-python-der-ai-feedback-loop-revolutioniert-die-entwicklung/index.md
@@ -76,7 +76,7 @@ Die Integration in bestehende Automatisierungs-Stacks wie Zapier, n8n oder Make 
 ## Quellen & Weiterführende Links
 - 📰 [Original GitHub Blog Artikel](https://github.blog/news-insights/octoverse/typescript-python-and-the-ai-feedback-loop-changing-software-development/)
 - 📚 [GitHub Octoverse 2025 Report](https://octoverse.github.com)
-- 🎓 [TypeScript für Automatisierung - Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=typescript-ueberholt-python-der-ai-feedback-loop-revolutioniert-die-entwicklung)
+- 🎓 [TypeScript für Automatisierung - Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=typescript-ueberholt-python-der-ai-feedback-loop-revolutioniert-die-entwicklung)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 2025-11-14*
 ---

--- a/src/pages/blog/2025-11-15-baidu-revolutioniert-ki-automatisierung-ernie-4-5-vl-als-open-source-alternative-zu-gpt-5/index.md
+++ b/src/pages/blog/2025-11-15-baidu-revolutioniert-ki-automatisierung-ernie-4-5-vl-als-open-source-alternative-zu-gpt-5/index.md
@@ -97,7 +97,7 @@ Für AI-Automation Engineers bedeutet dies: Endlich eine echte Alternative zu pr
 - 📚 [ERNIE-4.5-VL Offizielle Dokumentation](https://ernie.baidu.com/blog/posts/ernie-4.5-vl-28b-a3b-thinking/)
 - 🔧 [GitHub Repository - PaddlePaddle ERNIE](https://github.com/PaddlePaddle/ERNIE)
 - 🎥 [Lokale Installation Tutorial](https://www.youtube.com/watch?v=nbXgKPNpJJg)
-- 🎓 [AI-Automation Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=baidu-revolutioniert-ki-automatisierung-ernie-4-5-vl-als-open-source-alternative-zu-gpt-5)
+- 🎓 [AI-Automation Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=baidu-revolutioniert-ki-automatisierung-ernie-4-5-vl-als-open-source-alternative-zu-gpt-5)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 2025-11-15*
 ---

--- a/src/pages/blog/2025-11-15-github-copilot-instructions-files-der-game-changer-fuer-automatisierte-code-reviews/index.md
+++ b/src/pages/blog/2025-11-15-github-copilot-instructions-files-der-game-changer-fuer-automatisierte-code-reviews/index.md
@@ -131,7 +131,7 @@ Für Automatisierungs-Engineers bedeutet das: Weniger Zeit mit repetitiven Revie
 ## Quellen & Weiterführende Links
 - 📚 [Offizielle GitHub Copilot Code Review Docs](https://docs.github.com/copilot/using-github-copilot/code-review/using-copilot-code-review)
 - 📊 [GitHub Research: Copilot Code Quality](https://github.blog/news-insights/research/does-github-copilot-improve-code-quality-heres-what-the-data-says/)
-- 🎓 [Workshop: AI-Driven Development auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-instructions-files-der-game-changer-fuer-automatisierte-code-reviews)
+- 🎓 [Workshop: AI-Driven Development auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-instructions-files-der-game-changer-fuer-automatisierte-code-reviews)
 - 🔧 [Custom Instructions Tutorial](https://docs.github.com/en/copilot/tutorials/use-custom-instructions)
 - 📈 [GitHub Copilot Code Review Konzepte](https://docs.github.com/en/copilot/concepts/agents/code-review)
 ---

--- a/src/pages/blog/2025-11-15-gpt-5-1-adaptive-reasoning-revolutioniert-ai-workflows/index.md
+++ b/src/pages/blog/2025-11-15-gpt-5-1-adaptive-reasoning-revolutioniert-ai-workflows/index.md
@@ -123,7 +123,7 @@ Für AI-Automation Engineers bedeutet das: Schnellere Entwicklung, stabilere Wor
 - 📚 [OpenAI API Documentation für GPT-5.1](https://platform.openai.com/docs/guides/latest-model)
 - 🔧 [GPT-5.1 Integration Guide](https://apidog.com/blog/gpt-5-1/)
 - 💡 [Practical GPT-5.1 Use Cases](https://natesnewsletter.substack.com/p/chatgpt-51-how-to-make-the-most-of)
-- 🎓 [AI-Automation Workshop: GPT-5.1 Integration](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=gpt-5-1-adaptive-reasoning-revolutioniert-ai-workflows)
+- 🎓 [AI-Automation Workshop: GPT-5.1 Integration](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=gpt-5-1-adaptive-reasoning-revolutioniert-ai-workflows)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 15.11.2025*
 ---

--- a/src/pages/blog/2025-11-17-github-copilot-trifft-azure-boards-ki-gesteuerte-task-automatisierung/index.md
+++ b/src/pages/blog/2025-11-17-github-copilot-trifft-azure-boards-ki-gesteuerte-task-automatisierung/index.md
@@ -124,7 +124,7 @@ Die Integration ist erst der Anfang. Microsoft plant weitere Features:
 ## Quellen & Weiterführende Links
 - 📰 [GitHub Changelog - Copilot Azure Boards Integration](https://github.blog/changelog/2025-10-copilot-azure-boards-integration)
 - 📚 [Microsoft DevOps Blog - Azure Boards Integration](https://devblogs.microsoft.com/devops/azure-boards-integration-with-github-copilot-private-preview)
-- 🎓 [Workshop: AI-Driven DevOps auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-trifft-azure-boards-ki-gesteuerte-task-automatisierung)
+- 🎓 [Workshop: AI-Driven DevOps auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-trifft-azure-boards-ki-gesteuerte-task-automatisierung)
 - 🔧 [GitHub Copilot Dokumentation](https://docs.github.com/copilot)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 2025-10-22*

--- a/src/pages/blog/2025-11-17-github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows/index.md
+++ b/src/pages/blog/2025-11-17-github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows/index.md
@@ -177,7 +177,7 @@ Das ist nicht mehr "Low-Code" — das ist **"Talk-to-Ship"** Automation.
 - 📚 [GitHub Spark Official Docs](https://docs.github.com/de/copilot/concepts/spark)
 - 🎓 [Your First Spark Tutorial](https://docs.github.com/en/copilot/tutorials/spark/your-first-spark)
 - 🎬 [GitHub Spark Demo Video](https://www.youtube.com/watch?v=oM2amcnVmzM)
-- 🎓 [Workshops.de: Automation Engineering Masterclass](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows)
+- 🎓 [Workshops.de: Automation Engineering Masterclass](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows)
 ---
 *Recherchiert und technisch verifiziert | Stand: 17.11.2025*
 ---
@@ -220,4 +220,4 @@ Wir bieten spezialisierte Workshops für:
 - ✅ KI-Automation mit n8n + Spark
 - ✅ Enterprise-Integration & Best Practices
 - ✅ Custom Automation Stack Design
-[📧 Kontakt zu unserem Workshop-Team](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows)
+[📧 Kontakt zu unserem Workshop-Team](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-spark-ki-gesteuerte-full-stack-app-entwicklung-fuer-automatisierungs-workflows)

--- a/src/pages/blog/2025-11-17-n8n-guardrails-die-neue-sicherheitsschicht-fuer-ki-automatisierung/index.md
+++ b/src/pages/blog/2025-11-17-n8n-guardrails-die-neue-sicherheitsschicht-fuer-ki-automatisierung/index.md
@@ -107,7 +107,7 @@ Für Teams, die bereits mit n8n arbeiten, ist die Adoption ein No-Brainer. Die Z
 ## Quellen & Weiterführende Links
 - 📰 [Offizielle n8n Release Notes](https://docs.n8n.io/release-notes/)
 - 📚 [LangChain in n8n - Übersicht](https://docs.n8n.io/advanced-ai/langchain/overview/)
-- 🎓 [Workshop: KI-Automation mit n8n](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=n8n-guardrails-die-neue-sicherheitsschicht-fuer-ki-automatisierung)
+- 🎓 [Workshop: KI-Automation mit n8n](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=n8n-guardrails-die-neue-sicherheitsschicht-fuer-ki-automatisierung)
 - 📹 [Video: How the NEW n8n Guardrails work](https://www.youtube.com/watch?v=P4A1TmGgzws)
 - 🔧 [n8n Community Forum - Guardrails Diskussion](https://community.n8n.io/)
 ---

--- a/src/pages/blog/2025-11-17-ollama-das-open-source-framework-fuer-private-ai-automation-ohne-cloud-abhaengigkeit/index.md
+++ b/src/pages/blog/2025-11-17-ollama-das-open-source-framework-fuer-private-ai-automation-ohne-cloud-abhaengigkeit/index.md
@@ -186,7 +186,7 @@ Für AI-Automation Engineers, die nachhaltige, kosteneffiziente und datenschutzk
 - 📚 [Ollama GitHub Repository](https://github.com/ollama/ollama)
 - 🔧 [n8n Ollama Integration Docs](https://n8n.io/integrations/ollama/)
 - 📺 [Ollama + n8n Workflow Tutorial](https://www.youtube.com/watch?v=VDuA5xbkEjo)
-- 🎓 [AI-Automation Workshop: Local LLMs in Production](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=ollama-das-open-source-framework-fuer-private-ai-automation-ohne-cloud-abhaengigkeit)
+- 🎓 [AI-Automation Workshop: Local LLMs in Production](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=ollama-das-open-source-framework-fuer-private-ai-automation-ohne-cloud-abhaengigkeit)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 23.10.2025 | Technical Review: 17.11.2025*
 ---

--- a/src/pages/blog/2025-11-17-openai-sicherheitsreport/index.md
+++ b/src/pages/blog/2025-11-17-openai-sicherheitsreport/index.md
@@ -149,7 +149,7 @@ Die gute Nachricht: Mit den richtigen Tools und Workflows lässt sich ein hohes 
 ## Quellen & Weiterführende Links
 - 📰 [OpenAI Threat Intelligence Report Februar 2025](https://cdn.openai.com/threat-intelligence-reports/disrupting-malicious-uses-of-our-models-february-2025-update.pdf)
 - 📚 [OpenAI Global Affairs - Disrupting Malicious Uses](https://openai.com/global-affairs/disrupting-malicious-uses-of-ai/)
-- 🎓 [AI-Security Workshop bei workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-sicherheitsreport)
+- 🎓 [AI-Security Workshop bei workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-sicherheitsreport)
 - 🔧 [n8n Security Best Practices](https://docs.n8n.io/security/)
 - 🛡️ [Make.com API Security Guide](https://www.make.com/en/help/security)
 ---

--- a/src/pages/blog/2025-11-18-claude-code-browser-extensions-in-minuten-bauen-ohne-klassisches-coding/index.md
+++ b/src/pages/blog/2025-11-18-claude-code-browser-extensions-in-minuten-bauen-ohne-klassisches-coding/index.md
@@ -93,6 +93,6 @@ Besonders für Teams, die regelmäßig Custom-Integrationen oder Browser-basiert
 - 📚 [Claude Code Dokumentation](https://docs.anthropic.com/en/docs/claude-code/overview)
 - 🔧 [Best Practices für agentische Coding](https://www.anthropic.com/engineering/claude-code-best-practices)
 - 📖 [Claude Code Tutorial von DataCamp](https://www.datacamp.com/de/tutorial/claude-code)
-- 🎓 [Browser Extension Development Workshop](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-code-browser-extensions-in-minuten-bauen-ohne-klassisches-coding)
+- 🎓 [Browser Extension Development Workshop](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-code-browser-extensions-in-minuten-bauen-ohne-klassisches-coding)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 18.11.2025 | Technical Review durchgeführt*

--- a/src/pages/blog/2025-11-18-claude-haiku-4-5-3x-guenstiger-2x-schneller-die-neue-aera-kosteneffizienter-ki-automation/index.md
+++ b/src/pages/blog/2025-11-18-claude-haiku-4-5-3x-guenstiger-2x-schneller-die-neue-aera-kosteneffizienter-ki-automation/index.md
@@ -160,7 +160,7 @@ Mit Haiku 4.5's **Vision-Capabilities** (Bildverarbeitung) öffnen sich zusätzl
 - 📰 [Original Anthropic Announcement](https://www.anthropic.com/news/claude-haiku-4-5)
 - 📚 [Anthropic API Documentation](https://docs.anthropic.com)
 - 🔧 [Amazon Bedrock Integration Guide](https://aws.amazon.com/bedrock/)
-- 🎓 [AI & Automation Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-haiku-4-5-3x-guenstiger-2x-schneller-die-neue-aera-kosteneffizienter-ki-automation)
+- 🎓 [AI & Automation Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-haiku-4-5-3x-guenstiger-2x-schneller-die-neue-aera-kosteneffizienter-ki-automation)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 15.10.2025*
 ---

--- a/src/pages/blog/2025-11-18-claude-memory-game-changer-fuer-persistente-ai-workflows/index.md
+++ b/src/pages/blog/2025-11-18-claude-memory-game-changer-fuer-persistente-ai-workflows/index.md
@@ -142,7 +142,7 @@ Claude Memory ist mehr als nur ein nettes Feature - es ist ein fundamentaler Bau
 - 📰 [Offizielle Ankündigung von Anthropic](https://www.anthropic.com/news/memory)
 - 📚 [Claude API Dokumentation](https://docs.anthropic.com/claude/docs)
 - 🔧 [Community n8n Claude Node](https://github.com/n8n-io/n8n-nodes-claude-memory) *(in Entwicklung)*
-- 🎓 [Workshop: AI-gestützte Automation-Workflows](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-memory-game-changer-fuer-persistente-ai-workflows)
+- 🎓 [Workshop: AI-gestützte Automation-Workflows](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=claude-memory-game-changer-fuer-persistente-ai-workflows)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 27.10.2025 05:26 Uhr*
 ---

--- a/src/pages/blog/2025-11-18-github-copilot-custom-model/index.md
+++ b/src/pages/blog/2025-11-18-github-copilot-custom-model/index.md
@@ -81,7 +81,7 @@ Das neue Custom Model von GitHub Copilot ist mehr als nur ein Update – es ist 
 ## Quellen & Weiterführende Links
 - 📰 [Original GitHub Blog Artikel](https://github.blog/ai-and-ml/github-copilot/the-road-to-better-completions-building-a-faster-smarter-github-copilot-with-a-new-custom-model/)
 - 📚 [GitHub Copilot Custom Model Dokumentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-ai-models/create-a-custom-model)
-- 🎓 [AI-Automation Workshop: GitHub Copilot für Enterprises](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-custom-model)
+- 🎓 [AI-Automation Workshop: GitHub Copilot für Enterprises](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=github-copilot-custom-model)
 - 🔗 [GitHub Copilot Enterprise Features](https://github.com/features/copilot)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 23.10.2024 | Review: 18.11.2025*

--- a/src/pages/blog/2025-11-18-google-project-jarvis-der-ai-agent-der-web-aufgaben-autonom-erledigt/index.md
+++ b/src/pages/blog/2025-11-18-google-project-jarvis-der-ai-agent-der-web-aufgaben-autonom-erledigt/index.md
@@ -113,7 +113,7 @@ Für Automation Engineers eröffnen sich damit neue Rollen als "AI-Agent-Orchest
 - 📰 [Original-Artikel Testing Catalog](https://www.testingcatalog.com/google-prepares-gemini-agent-to-perform-tasks-for-you/)
 - 📚 [Google Gemini Dokumentation](https://cloud.google.com/gemini/docs)
 - 🔧 [Chrome DevTools für Automation](https://developer.chrome.com/docs/devtools/)
-- 🎓 [AI-Automation Workshop auf workshops.de](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=google-project-jarvis-der-ai-agent-der-web-aufgaben-autonom-erledigt)
+- 🎓 [AI-Automation Workshop auf workshops.de](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=google-project-jarvis-der-ai-agent-der-web-aufgaben-autonom-erledigt)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 25.10.2024*
 ---

--- a/src/pages/blog/2025-11-18-openai-shared-projects/index.md
+++ b/src/pages/blog/2025-11-18-openai-shared-projects/index.md
@@ -126,7 +126,7 @@ ChatGPT Shared Projects transformiert die Art, wie Teams mit KI arbeiten. Für A
 ## Quellen & Weiterführende Links
 - 📰 [Original OpenAI Announcement](https://openai.com/index/more-ways-to-work-with-your-team/)
 - 📚 [Official Documentation - Using Projects in ChatGPT](https://help.openai.com/en/articles/10169521-using-projects-in-chatgpt)
-- 🎓 [Workshop: AI-Automation mit ChatGPT & Co.](https://workshops.de?utm_source=blog&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-shared-projects)
+- 🎓 [Workshop: AI-Automation mit ChatGPT & Co.](https://workshops.de?utm_source=ai-automation-engineers.de&utm_medium=referral&utm_campaign=article_referral&utm_content=openai-shared-projects)
 - 📊 [ChatGPT Release Notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes)
 ---
 *Recherchiert mit: Perplexity AI | Stand: 27. Oktober 2025*


### PR DESCRIPTION
Update all `workshops.de` links in blog articles to point to the main page and add UTM parameters.

This fixes 404 errors from non-existent subpages and enables better traffic tracking by adding `utm_source=blog`, `utm_medium=referral`, `utm_campaign=article_referral`, and `utm_content={artikel-slug}` to each link.

---
<a href="https://cursor.com/background-agent?bcId=bc-f71248b7-9fe4-4ca4-9df6-998eb6f900cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f71248b7-9fe4-4ca4-9df6-998eb6f900cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

