### PR TITLE
fix(ci): add cursor bot to allowed_bots in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: "dependabot"
+          allowed_bots: "dependabot,cursor"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `claude-code-review` workflow was failing with:

```
Action failed with error: Workflow initiated by non-human actor: cursor (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

The `cursor` bot opens PRs automatically, but was not listed in the `allowed_bots` configuration of the `anthropics/claude-code-action` step.

## Fix

Added `cursor` to the `allowed_bots` list alongside the existing `dependabot` entry.

Fixes the build failure seen in https://github.com/workshops-de/ai-automation-engineers.de/actions/runs/24599939150/job/71936814472
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2f6dfc0-4d94-4394-8efc-5fcd3522aa78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2f6dfc0-4d94-4394-8efc-5fcd3522aa78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

