### PR TITLE
fix(content): replace broken header image in claude code plugin marketplace article

### DIFF
--- a/src/pages/news/2026-04-18-claude-code-bekommt-offiziellen-plugin-marketplace-offizielles-anthropic-plugin-verzeichnis/index.md
+++ b/src/pages/news/2026-04-18-claude-code-bekommt-offiziellen-plugin-marketplace-offizielles-anthropic-plugin-verzeichnis/index.md
@@ -7,7 +7,7 @@ author: 'Robin Böhm'
 tags: ['AI', 'Automation', 'Technology']
 category: 'Technology'
 readTime: '5 min read'
-image: 'https://images.unsplash.com/photo-1711929639928-c5a06a20e8ed?w=1200&h=600&fit=crop'
+image: 'https://images.unsplash.com/photo-1607798748738-b15c40d33d57?w=1200&h=600&fit=crop'
 ---
 
 **TL;DR:** Anthropic hat mit `claude-plugins-official` ein offizielles, kuratiertes Plugin-Verzeichnis für Claude Code auf GitHub veröffentlicht. Installation per `/plugin install`, MCP-basiert, Python/TypeScript/Shell – ein standardisiertes Ökosystem für wiederverwendbare Claude Code Plugins.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The header image of the article "Claude Code bekommt offiziellen Plugin-Marketplace" (2026-04-18) was returning a 404 error. The Unsplash image `photo-1711929639928-c5a06a20e8ed` no longer exists at that URL.

## Fix

Replaced the broken image URL with a working Unsplash image (`photo-1607798748738-b15c40d33d57`) that fits the coding/technology theme of the article.

**Affected file:**  
`src/pages/news/2026-04-18-claude-code-bekommt-offiziellen-plugin-marketplace-offizielles-anthropic-plugin-verzeichnis/index.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ec7c18a-e54b-46f5-b101-ed73a9e98e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ec7c18a-e54b-46f5-b101-ed73a9e98e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

