### PR TITLE
fix(news): replace broken header image in mcp flaw article

### DIFF
--- a/src/pages/news/2026-04-25-mcp-flaw-by-design-wie-anthropics-stdio-schnittstelle-millionen-ki-workflows-gefaehrdet/index.md
+++ b/src/pages/news/2026-04-25-mcp-flaw-by-design-wie-anthropics-stdio-schnittstelle-millionen-ki-workflows-gefaehrdet/index.md
@@ -7,7 +7,7 @@ author: 'Robin Böhm'
 tags: ['AI', 'Automation', 'Technology']
 category: 'Technology'
 readTime: '5 min read'
-image: 'https://images.unsplash.com/photo-1676573284440-61fa6d0c8bce?w=1200&h=600&fit=crop'
+image: 'https://images.unsplash.com/photo-1744640326166-433469d102f2?w=1200&h=600&fit=crop'
 ---
 
 **TL;DR:** OX Security hat eine architektonische Schwachstelle im Model Context Protocol (MCP) von Anthropic aufgedeckt, die beliebige OS-Befehle ohne jede Sanitization ausführt – und Anthropic bezeichnet das als „expected behavior".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The header image for the MCP-Flaw article (`2026-04-25-mcp-flaw-by-design-...`) was broken — the Unsplash URL `photo-1676573284440-61fa6d0c8bce` returned HTTP 404.

## Solution

Replaced with a free Unsplash photo: **"Glowing AI chip on a circuit board"** by Immo Wegmann (`photo-1744640326166-433469d102f2`).

The new image is:
- Free (no Unsplash+ required)
- Thematically fitting — AI chip/hardware security aligns well with the article about Anthropic's MCP STDIO security flaw
- Verified accessible (HTTP 200)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73a7ffdf-f0c5-4f31-97c0-8ebfd5fe454c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73a7ffdf-f0c5-4f31-97c0-8ebfd5fe454c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

